### PR TITLE
Allow update to 10.7.0RC2 at beta channel

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -81,15 +81,11 @@ return [
 	'production' => [
 	],
 	'stable' => [
-		'10.5' => [
-			'latest' => '10.6.0',
-			'web' => 'https://doc.owncloud.org/server/10.5/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	'beta' => [
-		'10.5' => [
-			'latest' => '10.6.0',
-			'web' => 'https://doc.owncloud.org/server/10.5/admin_manual/maintenance/upgrade.html',
+		'10.6' => [
+			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.7.0RC1-qa.zip',
+			'web' => 'https://doc.owncloud.org/server/10.6/admin_manual/maintenance/upgrade.html',
 		],
 	],
 	'daily' => [
@@ -97,20 +93,20 @@ return [
 			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-master.zip',
 			'web' => 'https://doc.owncloud.org/server/10.6/admin_manual/maintenance/upgrade.html',
 		],
-		'10.5' => [
-			'latest' => '10.6.0',
-			'web' => 'https://doc.owncloud.org/server/10.5/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	// to prevent individual channels from bloating all upgrade path common for all channels go below
 	// if you move anything here make sure you updated 'eol_latest' key 
 	'eol' => [
+		'10.5' => [
+			'latest' => '10.6.0',
+			'web' => 'https://doc.owncloud.org/server/10.5/admin_manual/maintenance/upgrade.html',
+		],
 		'10.4.100' => [
-			'latest' => '10.5.0',
+			'latest' => '10.6.0',
 			'web' => 'https://doc.owncloud.org/server/10.4/admin_manual/maintenance/upgrade.html',
 		],
 		'10.4.1' => [
-			'latest' => '10.5.0',
+			'latest' => '10.6.0',
 			'web' => 'https://doc.owncloud.org/server/10.5/admin_manual/maintenance/upgrade.html',
 		],
 		// 10.4.1 is the most recent with PHP 7.1 support. So 10.3.0 - 10.4.0 should always update through it
@@ -241,5 +237,5 @@ return [
 			'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
 		],
 	],
-	'eol_latest' => '10.4.100',
+	'eol_latest' => '10.5.100',
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -84,7 +84,8 @@ return [
 	],
 	'beta' => [
 		'10.6' => [
-			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.7.0RC1-qa.zip',
+			'latest' => '10.7.0RC2',
+			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.7.0RC2-qa.zip',
 			'web' => 'https://doc.owncloud.org/server/10.6/admin_manual/maintenance/upgrade.html',
 		],
 	],

--- a/tests/integration/features/update.beta.feature
+++ b/tests/integration/features/update.beta.feature
@@ -12,7 +12,8 @@ Feature: Testing the update scenario of releases on the beta channel
     Given There is a release with channel "beta"
     And The received version is "10.6.0"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.7.0RC2-qa.zip"
 
   ##### Tests for 10.5.0 should go below #####
   Scenario: Updating an ownCloud 10.5.0 on the beta channel

--- a/tests/integration/features/update.beta.feature
+++ b/tests/integration/features/update.beta.feature
@@ -1,6 +1,12 @@
 Feature: Testing the update scenario of releases on the beta channel
 ##### Please always order by version number descending #####
-
+  ##### Tests for 10.7.x should go below #####
+  Scenario: Updating an outdated ownCloud 10.7.0 on the beta channel
+    Given There is a release with channel "beta"
+    And The received version is "10.7.0"
+    When The request is sent
+    Then The response is empty
+    
   ##### Tests for 10.6.0 should go below #####
   Scenario: Updating an ownCloud 10.6.0 on the beta channel
     Given There is a release with channel "beta"
@@ -22,7 +28,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "10.4.1"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.5.0.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
   
   Scenario: Updating an ownCloud 10.4.0 on the beta channel
     Given There is a release with channel "beta"

--- a/tests/integration/features/update.daily.feature
+++ b/tests/integration/features/update.daily.feature
@@ -1,5 +1,12 @@
 Feature: Testing the update scenario of releases on the daily channel
 ##### Please always order by version number descending #####
+  ##### Tests for 10.7 should go below #####
+  Scenario: Updating an outdated-dated ownCloud 10.7 daily
+    Given There is a release with channel "daily"
+    And The received version is "10.7.100"
+    And the received build is "2021-03-19T18:44:30+00:00"
+    When The request is sent
+    Then The response is empty
 
   ##### Tests for 10.6 should go below #####
   Scenario: Updating an outdated-dated ownCloud 10.6 daily
@@ -11,7 +18,6 @@ Feature: Testing the update scenario of releases on the daily channel
     And Update to version "100.0.0.0" is available
     And URL to download is "https://download.owncloud.org/community/owncloud-daily-master.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.6/admin_manual/maintenance/upgrade.html"
-
 
   ##### Tests for 10.5 should go below #####
   Scenario: Updating an outdated-dated ownCloud 10.5 daily
@@ -32,7 +38,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.5.0.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.4/admin_manual/maintenance/upgrade.html"
     
   ##### Tests for 10.3 should go below #####

--- a/tests/integration/features/update.production.feature
+++ b/tests/integration/features/update.production.feature
@@ -1,6 +1,13 @@
 Feature: Testing the update scenario of releases on the production channel
 ##### Please always order by version number descending #####
 
+  ##### Tests for 10.7.x should go below #####
+  Scenario: Updating an outdated ownCloud 10.7.0 on the production channel
+    Given There is a release with channel "production"
+    And The received version is "10.7.0"
+    When The request is sent
+    Then The response is empty
+
   ##### Tests for 10.6.x should go below #####
   Scenario: Updating an outdated ownCloud 10.6.0 on the production channel
     Given There is a release with channel "production"
@@ -13,7 +20,8 @@ Feature: Testing the update scenario of releases on the production channel
     Given There is a release with channel "production"
     And The received version is "10.5.0"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
 
   ##### Tests for 10.4.x should go below #####
   Scenario: Updating an outdated ownCloud 10.4.1 on the production channel
@@ -21,7 +29,7 @@ Feature: Testing the update scenario of releases on the production channel
     And The received version is "10.4.1"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.5.0.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
     
   Scenario: Updating an outdated ownCloud 10.4.0 on the production channel
     Given There is a release with channel "production"

--- a/tests/integration/features/update.stable.feature
+++ b/tests/integration/features/update.stable.feature
@@ -1,6 +1,13 @@
 Feature: Testing the update scenario of releases on the stable channel
 ##### Please always order by version number descending #####
 
+  ##### Tests for 10.7.x should go below #####
+  Scenario: Updating an outdated ownCloud 10.7.0 on the stable channel
+    Given There is a release with channel "stable"
+    And The received version is "10.7.0"
+    When The request is sent
+    Then The response is empty
+
   ##### Tests for 10.6.x should go below #####
   Scenario: Updating an ownCloud 10.6.0 on the stable channel
     Given There is a release with channel "stable"
@@ -22,7 +29,7 @@ Feature: Testing the update scenario of releases on the stable channel
     And The received version is "10.4.1"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.5.0.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
     
   Scenario: Updating an ownCloud 10.4.0 on the stable channel
     Given There is a release with channel "stable"


### PR DESCRIPTION
- Allow update to 10.7.0RC2 at beta channel
- Allow direct update to 10.6 from 10.4.1
- prepare tests for 10.7
- move 10.5 to common channel