### PR TITLE
Release 10.8.0rc1

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -81,10 +81,6 @@ return [
 	'production' => [
 	],
 	'stable' => [
-		'10.6' => [
-			'latest' => '10.7.0',
-			'web' => 'https://doc.owncloud.org/server/10.6/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	'beta' => [
 		'10.7' => [
@@ -92,34 +88,30 @@ return [
 			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.8.0beta2-qa.zip',
 			'web' => 'https://doc.owncloud.org/server/10.7/admin_manual/maintenance/upgrade.html',
 		],
-		'10.6' => [
-			'latest' => '10.7.0',
-			'web' => 'https://doc.owncloud.org/server/10.6/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	'daily' => [
 		'10.7' => [
 			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-master.zip',
 			'web' => 'https://doc.owncloud.org/server/10.7/admin_manual/maintenance/upgrade.html',
 		],
-		'10.6' => [
-			'latest' => '10.7.0',
-			'web' => 'https://doc.owncloud.org/server/10.6/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	// to prevent individual channels from bloating all upgrade path common for all channels go below
 	// if you move anything here make sure you updated 'eol_latest' key 
 	'eol' => [
+		'10.6' => [
+			'latest' => '10.7.0',
+			'web' => 'https://doc.owncloud.org/server/10.6/admin_manual/maintenance/upgrade.html',
+		],
 		'10.5' => [
-			'latest' => '10.6.0',
+			'latest' => '10.7.0',
 			'web' => 'https://doc.owncloud.org/server/10.5/admin_manual/maintenance/upgrade.html',
 		],
 		'10.4.100' => [
-			'latest' => '10.6.0',
+			'latest' => '10.7.0',
 			'web' => 'https://doc.owncloud.org/server/10.4/admin_manual/maintenance/upgrade.html',
 		],
 		'10.4.1' => [
-			'latest' => '10.6.0',
+			'latest' => '10.7.0',
 			'web' => 'https://doc.owncloud.org/server/10.5/admin_manual/maintenance/upgrade.html',
 		],
 		// 10.4.1 is the most recent with PHP 7.1 support. So 10.3.0 - 10.4.0 should always update through it
@@ -250,5 +242,5 @@ return [
 			'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
 		],
 	],
-	'eol_latest' => '10.5.100',
+	'eol_latest' => '10.6.100',
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -84,8 +84,8 @@ return [
 	],
 	'beta' => [
 		'10.7' => [
-			'latest' => '10.8.0beta2',
-			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.8.0beta2-qa.zip',
+			'latest' => '10.8.0rc1',
+			'downloadUrl' => 'https://download.owncloud.org/community/testing/owncloud-10.8.0RC1-qa.zip',
 			'web' => 'https://doc.owncloud.org/server/10.7/admin_manual/maintenance/upgrade.html',
 		],
 	],

--- a/tests/integration/features/update.beta.feature
+++ b/tests/integration/features/update.beta.feature
@@ -13,7 +13,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "10.7.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.8.0beta2-qa.zip"
+    And URL to download is "https://download.owncloud.org/community/testing/owncloud-10.8.0RC1-qa.zip"
     
   ##### Tests for 10.6.0 should go below #####
   Scenario: Updating an ownCloud 10.6.0 on the beta channel

--- a/tests/integration/features/update.beta.feature
+++ b/tests/integration/features/update.beta.feature
@@ -29,7 +29,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "10.5.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.7.0.zip"
 
   ##### Tests for 10.4.x should go below #####
   Scenario: Updating an ownCloud 10.4.1 on the beta channel
@@ -37,7 +37,7 @@ Feature: Testing the update scenario of releases on the beta channel
     And The received version is "10.4.1"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.7.0.zip"
   
   Scenario: Updating an ownCloud 10.4.0 on the beta channel
     Given There is a release with channel "beta"

--- a/tests/integration/features/update.daily.feature
+++ b/tests/integration/features/update.daily.feature
@@ -30,7 +30,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.7.0.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.5/admin_manual/maintenance/upgrade.html"
     
   ##### Tests for 10.4 should go below #####
@@ -41,7 +41,7 @@ Feature: Testing the update scenario of releases on the daily channel
     When The request is sent
     Then The response is non-empty
     And Update to version "100.0.0.0" is available
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.7.0.zip"
     And URL to documentation is "https://doc.owncloud.org/server/10.4/admin_manual/maintenance/upgrade.html"
     
   ##### Tests for 10.3 should go below #####

--- a/tests/integration/features/update.production.feature
+++ b/tests/integration/features/update.production.feature
@@ -13,7 +13,8 @@ Feature: Testing the update scenario of releases on the production channel
     Given There is a release with channel "production"
     And The received version is "10.6.0"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.7.0.zip"
 
   ##### Tests for 10.5.x should go below #####
   Scenario: Updating an outdated ownCloud 10.5.0 on the production channel
@@ -21,7 +22,7 @@ Feature: Testing the update scenario of releases on the production channel
     And The received version is "10.5.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.7.0.zip"
 
   ##### Tests for 10.4.x should go below #####
   Scenario: Updating an outdated ownCloud 10.4.1 on the production channel
@@ -29,7 +30,7 @@ Feature: Testing the update scenario of releases on the production channel
     And The received version is "10.4.1"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.7.0.zip"
     
   Scenario: Updating an outdated ownCloud 10.4.0 on the production channel
     Given There is a release with channel "production"

--- a/tests/integration/features/update.stable.feature
+++ b/tests/integration/features/update.stable.feature
@@ -22,7 +22,7 @@ Feature: Testing the update scenario of releases on the stable channel
     And The received version is "10.5.0"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.7.0.zip"
 
   ##### Tests for 10.4.x should go below #####
   Scenario: Updating an ownCloud 10.4.1 on the stable channel
@@ -30,7 +30,7 @@ Feature: Testing the update scenario of releases on the stable channel
     And The received version is "10.4.1"
     When The request is sent
     Then The response is non-empty
-    And URL to download is "https://download.owncloud.org/community/owncloud-10.6.0.zip"
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.7.0.zip"
     
   Scenario: Updating an ownCloud 10.4.0 on the stable channel
     Given There is a release with channel "stable"


### PR DESCRIPTION
- Unlock 10.7.0 at the production channel
- Allow direct upgrade from 10.4.1+ to 10.7.0. 
- Use 10.8.0rc1 instead of 10.8.0beta2 at the beta channel

