### PR TITLE
Unlock 10.8.0 at the production channel

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -81,30 +81,23 @@ return [
 	'production' => [
 	],
 	'stable' => [
-		'10.7' => [
-			'latest' => '10.8.0',
-			'web' => 'https://doc.owncloud.org/server/10.7/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	'beta' => [
-		'10.7' => [
-			'latest' => '10.8.0',
-			'web' => 'https://doc.owncloud.org/server/10.7/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	'daily' => [
 		'10.8' => [
 			'downloadUrl' => 'https://download.owncloud.org/community/owncloud-daily-master.zip',
 			'web' => 'https://doc.owncloud.org/server/10.8/admin_manual/maintenance/upgrade.html',
 		],
-		'10.7' => [
-			'latest' => '10.8.0',
-			'web' => 'https://doc.owncloud.org/server/10.7/admin_manual/maintenance/upgrade.html',
-		],
 	],
 	// to prevent individual channels from bloating all upgrade path common for all channels go below
 	// if you move anything here make sure you updated 'eol_latest' key 
 	'eol' => [
+		// 10.8.0 is the most recent with PHP 7.2 support. So 10.4.1 - 10.7.0 should always update through it
+		'10.7' => [
+			'latest' => '10.8.0',
+			'web' => 'https://doc.owncloud.org/server/10.7/admin_manual/maintenance/upgrade.html',
+		],
 		'10.6' => [
 			'latest' => '10.8.0',
 			'web' => 'https://doc.owncloud.org/server/10.6/admin_manual/maintenance/upgrade.html',
@@ -249,5 +242,5 @@ return [
 			'web' => 'https://doc.owncloud.org/server/7.0/admin_manual/maintenance/upgrade.html',
 		],
 	],
-	'eol_latest' => '10.6.100',
+	'eol_latest' => '10.7.100',
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -66,7 +66,7 @@
  * This configuration array would have the following meaning:
  *
  * 1. 8.2.0 instances would be delivered 8.2.1
- * 2. All instances below 8.2.4 EXCEPT 8.2.1 would be delivered 8.2.4
+ * 2. All instances below 8.2.4 EXCEPT 8.2.0 and 8.2.4 would be delivered 8.2.4
  * 3. 8.2.4 instances get 9.0.0 delivered
  *
  * Oh. And be a nice person and also adjust the integration tests at /tests/integration/features/update.feature after doing

--- a/tests/integration/features/update.production.feature
+++ b/tests/integration/features/update.production.feature
@@ -12,7 +12,8 @@ Feature: Testing the update scenario of releases on the production channel
     Given There is a release with channel "production"
     And The received version is "10.7.0"
     When The request is sent
-    Then The response is empty
+    Then The response is non-empty
+    And URL to download is "https://download.owncloud.org/community/owncloud-10.8.0.zip"
 
   ##### Tests for 10.6.x should go below #####
   Scenario: Updating an outdated ownCloud 10.6.0 on the production channel


### PR DESCRIPTION
with regard to https://github.com/owncloud/core/pull/38697 that makes PHP 7.2 unsupported in 10.9.0